### PR TITLE
chore: get the build and release working

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,9 @@ defaults:
     # to fail on error in multiline statements (-e), in pipes (-o pipefail), and on unset variables (-u).
     shell: bash -euo pipefail {0}
 
+permissions:
+  contents: read
+
 jobs:
   package:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/scldm
     permissions:
+      contents: read
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - uses: actions/checkout@v4
@@ -29,6 +30,8 @@ jobs:
         with:
           cache-dependency-glob: pyproject.toml
       - name: Build package
-        run: uv build
+        run: |
+          uv build --sdist
+          uv build --wheel
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ defaults:
     # to fail on error in multiline statements (-e), in pipes (-o pipefail), and on unset variables (-u).
     shell: bash -euo pipefail {0}
 
+permissions:
+  contents: read
+
 jobs:
   # Get the test environment from hatch as defined in pyproject.toml.
   # This ensures that the pyproject.toml is the single point of truth for test definitions and the same tests are

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,9 @@ buck-out/
 __pycache__/
 .*cache/
 
-# Distribution / packaging
+# Distribution / packaging (these are generated at build time)
 /dist/
+src/scldm/_version.py
 
 # Tests and coverage
 /data/

--- a/README.md
+++ b/README.md
@@ -18,20 +18,27 @@ in particular, the [API documentation][].
 You need to have Python 3.11 or newer installed on your system.
 If you don't have Python installed, we recommend installing [uv][].
 
-There are several alternative options to install scldm:
-
-<!--
-1) Install the latest release of `scldm` from [PyPI][]:
+To install the latest release of `scldm` from [PyPI][]:
 
 ```bash
-pip install scldm
+pip install scldm "cellarium-ml @ git+https://github.com/cellarium-ai/cellarium-ml.git"
+# or
+uv pip install scldm "cellarium-ml @ git+https://github.com/cellarium-ai/cellarium-ml.git"
 ```
--->
 
-1. Install the latest development version:
+### Note On  Dependencies
 
+#### Cellarium-ML
+
+This model uses [cellarium-ml](https://github.com/cellarium-ai/cellarium-ml). Currently,
+the most recent version on PyPI (0.0.7) is not compatible with `anndata>=0.10.9`,
+which this model uses. You must install a newer version of `cellarium-ml` from source:
+
+You can install cellarium-ml separately with:
 ```bash
-pip install git+https://github.com/czi-ai/scldm.git@main
+pip install "cellarium-ml @ git+https://github.com/cellarium-ai/cellarium-ml.git"
+# or
+uv pip install "cellarium-ml @ git+https://github.com/cellarium-ai/cellarium-ml.git"
 ```
 
 ## Release notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
 build-backend = "hatchling.build"
-requires = [ "hatchling" ]
+requires = [ "hatchling", "hatch-vcs" ]
 
 [project]
 name = "scldm"
-version = "0.0.1"
+dynamic = ["version"]
 description = "single-cell latent diffusion model"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -23,7 +23,6 @@ classifiers = [
 ]
 dependencies = [
   "anndata",
-  "cellarium-ml @ git+https://github.com/cellarium-ai/cellarium-ml@main",
   "cellxgene-census==1.16.2",
   "einops",
   "ema-pytorch==0.7.7",
@@ -46,6 +45,10 @@ dependencies = [
   "torchdyn",
   "torchmetrics==1.6",
   "wandb",
+  # `cellarium-ml<=0.0.7` is not compatible with `anndata>=0.10.9` and there is no newer PyPI release
+  # Once `cellarium-ml>0.0.7` is available on PyPI, replace the below with: "cellarium-ml>0.0.7"
+  # Until then, this must be manually installed since PyPI does not allow direct references to dependencies
+  #"cellarium-ml @ git+https://github.com/cellarium-ai/cellarium-ml.git",
 ]
 optional-dependencies.dev = [
   "pre-commit",
@@ -78,6 +81,12 @@ Documentation = "https://czi-ai.github.io/scldm"
 Homepage = "https://github.com/czi-ai/scldm"
 Source = "https://github.com/czi-ai/scldm"
 
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/scldm/_version.py"
+
 [tool.hatch.metadata]
 allow-direct-references = true
 
@@ -92,7 +101,7 @@ scripts.build = "sphinx-build -M html docs docs/_build -W {args}"
 scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
 scripts.clean = "git clean -fdX -- {args:docs}"
 extra-dependencies = [
-  # Install cellarium-ml from git for docs
+  # Install cellarium-ml from git for docs (see note about PyPI version above)
   "cellarium-ml @ git+https://github.com/cellarium-ai/cellarium-ml.git",
 ]
 
@@ -108,6 +117,10 @@ python = [ "3.13" ]
 
 [tool.hatch.envs.hatch-test]
 features = [ "dev", "test" ]
+extra-dependencies = [
+  # Install cellarium-ml from git for tests (see note about PyPI version above)
+  "cellarium-ml @ git+https://github.com/cellarium-ai/cellarium-ml.git",
+]
 
 [tool.hatch.envs.hatch-test.overrides]
 # If the matrix variable `deps` is set to "pre",

--- a/src/scldm/datamodule.py
+++ b/src/scldm/datamodule.py
@@ -11,12 +11,20 @@ import anndata as ad
 import numpy as np
 import torch
 from anndata import AnnData
-from cellarium.ml.data import (
-    DistributedAnnDataCollection,
-    IterableDistributedAnnDataCollectionDataset,
-)
-from cellarium.ml.utilities.data import AnnDataField, convert_to_tensor
 from pytorch_lightning import LightningDataModule
+
+try:
+    from cellarium.ml.data import (
+        DistributedAnnDataCollection,
+        IterableDistributedAnnDataCollectionDataset,
+    )
+    from cellarium.ml.utilities.data import AnnDataField, convert_to_tensor
+except ImportError as e:
+    raise ImportError(
+        "cellarium-ml is required for DataModule functionality. "
+        "If `cellarium-ml>0.0.7` is available on PyPI, install with: pip install cellarium-ml . "
+        "Otherwise: pip install 'cellarium-ml @ git+https://github.com/cellarium-ai/cellarium-ml.git'"
+    ) from e
 from torch.utils._pytree import tree_map
 from torch.utils.data import DataLoader
 


### PR DESCRIPTION
- also use the git tag for version number
- add instructions for manually installing `cellarium-ml` since PyPI does not allow direct references to dependencies